### PR TITLE
Fix: Use DEFAULT_API_TIMEOUT consistently in Overpass query

### DIFF
--- a/brunnels/overpass.py
+++ b/brunnels/overpass.py
@@ -18,7 +18,7 @@ def query_overpass_brunnels(
 
     # Overpass QL query for both bridge and tunnel ways with geometry
     query = f"""
-[out:json][timeout:25];
+[out:json][timeout:{DEFAULT_API_TIMEOUT}];
 (
   way[bridge]({south},{west},{north},{east});
   way[tunnel]({south},{west},{north},{east});


### PR DESCRIPTION
The Overpass QL query in `brunnels/overpass.py` was using a hardcoded timeout value (25) that was different from the `DEFAULT_API_TIMEOUT` (30) used for the HTTP request.

This change updates the query to use the `DEFAULT_API_TIMEOUT` constant, ensuring consistency in timeout configurations.