### PR TITLE
Fix: Configure pytest pythonpath for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]


### PR DESCRIPTION
Added `[tool.pytest.ini_options]` to `pyproject.toml` to set `pythonpath = ["src"]`. This allows pytest to correctly discover and import the `brunnels` package located under the `src/` directory, resolving import errors that occurred after the project structure was changed to a src layout.

All tests now pass with this configuration.