### PR TITLE
Fix: Correct bearing calculation from poles

### DIFF
--- a/src/brunnels/geometry_utils.py
+++ b/src/brunnels/geometry_utils.py
@@ -181,6 +181,19 @@ def calculate_bearing(start_pos: Position, end_pos: Position) -> float:
     Returns:
         Bearing in degrees (0-360, where 0° is north, 90° is east)
     """
+    if start_pos == end_pos:
+        return 0.0
+
+    # Handle polar cases
+    if math.isclose(start_pos.latitude, 90.0):  # Start is North Pole
+        return 180.0
+    if math.isclose(start_pos.latitude, -90.0):  # Start is South Pole
+        return 0.0
+    if math.isclose(end_pos.latitude, 90.0):  # End is North Pole
+        return 0.0
+    if math.isclose(end_pos.latitude, -90.0):  # End is South Pole
+        return 180.0
+
     lat1 = math.radians(start_pos.latitude)
     lat2 = math.radians(end_pos.latitude)
     lon1 = math.radians(start_pos.longitude)


### PR DESCRIPTION
The `calculate_bearing` function was returning incorrect values when the starting position was the North or South Pole.

This change implements the following logic:
- If the start and end positions are identical, the bearing is 0 degrees.
- If the starting position is the North Pole (and not the same as the end position), the bearing is 180 degrees (South).
- If the starting position is the South Pole (and not the same as the end position), the bearing is 0 degrees (North).

These changes ensure that all assertions within the `test_calculate_bearing_poles` test case now pass. The standard bearing formula is retained for all other cases.