### PR TITLE
I've fixed incorrect assertions in `test_calculate_bearing_poles`.

### DIFF
--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -363,7 +363,7 @@ def test_calculate_bearing_poles():
     # From North Pole to some point
     north_pole = Position(latitude=90.0, longitude=0.0)
     point_south_of_np = Position(latitude=89.0, longitude=45.0) # Arbitrary longitude
-    assert calculate_bearing(north_pole, point_south_of_np) == pytest.approx(135.0) # Due South
+    assert calculate_bearing(north_pole, point_south_of_np) == pytest.approx(180.0) # Due South
 
     # To North Pole from some point
     point_near_np = Position(latitude=89.0, longitude=45.0)
@@ -372,7 +372,7 @@ def test_calculate_bearing_poles():
     # From South Pole to some point
     south_pole = Position(latitude=-90.0, longitude=0.0)
     point_north_of_sp = Position(latitude=-89.0, longitude=120.0) # Arbitrary longitude
-    assert calculate_bearing(south_pole, point_north_of_sp) == pytest.approx(120.0) # Due North
+    assert calculate_bearing(south_pole, point_north_of_sp) == pytest.approx(0.0) # Due North
 
     # To South Pole from some point
     point_near_sp = Position(latitude=-89.0, longitude=120.0)


### PR DESCRIPTION
The test `test_calculate_bearing_poles` in `tests/test_geometry_utils.py` contained incorrect expected values for bearings involving the North and South Poles.

- The bearing from the North Pole to a point south of it was asserted to be approximately 135.0 degrees, but the `calculate_bearing` function correctly returns 180.0 degrees. I've corrected this assertion to `pytest.approx(180.0)`.

- The bearing from the South Pole to a point north of it was asserted to be approximately 120.0 degrees, but the `calculate_bearing` function correctly returns 0.0 degrees. I've corrected this assertion to `pytest.approx(0.0)`.

All tests now pass after these corrections.