### PR TITLE
Refactor: Rename --buffer option to --bbox-buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If the output file already exists, the tool will automatically try numbered vari
 ```bash
 brunnels route.gpx \
   --output my_map.html \
-  --buffer 0.5 \
+  --bbox-buffer 0.5 \
   --route-buffer 5.0 \
   --bearing-tolerance 15.0 \
   --no-tag-filtering \
@@ -92,7 +92,7 @@ brunnels route.gpx \
 ```bash
 python3 -m brunnels.cli route.gpx \
   --output my_map.html \
-  --buffer 0.5 \
+  --bbox-buffer 0.5 \
   --route-buffer 5.0 \
   --bearing-tolerance 15.0 \
   --no-tag-filtering \
@@ -102,7 +102,7 @@ python3 -m brunnels.cli route.gpx \
 ### Options
 
 - `--output FILE`: Specify output HTML filename (default: auto-generated based on input filename)
-- `--buffer DISTANCE`: Search radius around route in kilometers (default: 0.1km)
+- `--bbox-buffer DISTANCE`: Search radius around route in kilometers (default: 0.1km)
 - `--route-buffer DISTANCE`: Route containment buffer in meters (default: 3.0m)
 - `--bearing-tolerance DEGREES`: Bearing alignment tolerance in degrees (default: 20.0°)
 - `--no-tag-filtering`: Disable filtering based on cycling relevance

--- a/src/brunnels/cli.py
+++ b/src/brunnels/cli.py
@@ -51,7 +51,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="Output HTML map file (default: auto-generated based on input filename)",
     )
     parser.add_argument(
-        "--buffer",
+        "--bbox-buffer",
         type=float,
         default=0.1,
         help="Search buffer around route in kilometers (default: 0.1)",
@@ -227,7 +227,7 @@ def main():
     # Find bridges and tunnels near the route (containment detection included)
     try:
         brunnels: Sequence[Brunnel] = route.find_brunnels(
-            args.buffer,
+            args.bbox_buffer,
             args.route_buffer,
             bearing_tolerance_degrees=args.bearing_tolerance,
             enable_tag_filtering=not args.no_tag_filtering,
@@ -258,7 +258,7 @@ def main():
 
     # Create visualization map
     try:
-        visualization.create_route_map(route, output_filename, brunnels, args.buffer)
+        visualization.create_route_map(route, output_filename, brunnels, args.bbox_buffer)
     except Exception as e:
         logger.error(f"Failed to create map: {e}")
         sys.exit(1)


### PR DESCRIPTION
This commit renames the command-line option `--buffer` to `--bbox-buffer` to better reflect its purpose of defining a buffer around the route's bounding box for querying OpenStreetMap data.

The following files were updated:
- src/brunnels/cli.py: Changed the argument definition and its usage.
- README.md: Updated documentation and examples.

No changes were needed in test files as they do not directly use this command-line option.